### PR TITLE
fix: make curly and math protections compatible

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -157,8 +157,8 @@ translate_part <- function(xml,
   woolish$body <- fakify_xml(xml)
 
   ## protect content inside curly braces and math ----
-  woolish$body <- tinkr::protect_curly(woolish$body)
   woolish$body <- tinkr::protect_math(woolish$body)
+  woolish$body <- tinkr::protect_curly(woolish$body)
   curlies <- xml2::xml_find_all(woolish$body, "//*[@curly]")
   purrr::walk(curlies, protect_curly)
   maths <- xml2::xml_find_all(woolish$body, "//*[@asis='true']")

--- a/inst/example-equations-curly.md
+++ b/inst/example-equations-curly.md
@@ -1,0 +1,5 @@
+---
+title: "les équations dans babeldown"
+---
+
+$a_{ij}$ 

--- a/tests/testthat/_snaps/translate.md
+++ b/tests/testthat/_snaps/translate.md
@@ -57,3 +57,10 @@
       [4] ""                                                 
       [5] ""                                                 
 
+# deepl_translate() handles equations with curly well
+
+    Code
+      foot_curly_lines[5]
+    Output
+      [1] "$a_{ij}$"
+

--- a/tests/testthat/fixtures/example-equations-curly/api/translate-adef71-POST.json
+++ b/tests/testthat/fixtures/example-equations-curly/api/translate-adef71-POST.json
@@ -1,0 +1,8 @@
+{
+    "translations": [
+        {
+            "detected_source_language": "FR",
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text xml:space=\"preserve\"/>\n    <math asis=\"true\">$a_{ij}$<\/math>\n    <text/>\n  <\/paragraph>\n<\/document>\n"
+        }
+    ]
+}

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -240,3 +240,21 @@ test_that("deepl_translate() handles equations+footnote well", {
   expect_snapshot(foot_math_lines)
 })
 
+
+test_that("deepl_translate() handles equations with curly well", {
+  to_translate <- system.file("example-equations-curly.md", package = "babeldown")
+  out_path <- withr::local_tempfile()
+  with_mock_dir("example-equations-curly", {
+    deepl_translate(
+      path = to_translate,
+      out_path = out_path,
+      source_lang = "FR",
+      target_lang = "EN-US",
+      yaml_fields = NULL
+    )
+  })
+  foot_curly_lines <- brio::read_lines(out_path)
+  expect_snapshot(foot_curly_lines[5])
+})
+
+


### PR DESCRIPTION
Fix  #68